### PR TITLE
#6 Extend ChangeBoundsCommand to set size or position independently

### DIFF
--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelServerAccess.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelServerAccess.java
@@ -24,8 +24,10 @@ import org.eclipse.emfcloud.modelserver.command.CCompoundCommand;
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
 import org.eclipse.emfcloud.modelserver.glsp.notation.Shape;
 import org.eclipse.emfcloud.modelserver.glsp.notation.commands.contribution.ChangeBoundsCommandContribution;
+import org.eclipse.glsp.graph.GDimension;
 import org.eclipse.glsp.graph.GModelElement;
 import org.eclipse.glsp.graph.GNode;
+import org.eclipse.glsp.graph.GPoint;
 import org.eclipse.glsp.server.protocol.GLSPServerException;
 import org.eclipse.glsp.server.types.ElementAndBounds;
 
@@ -56,14 +58,25 @@ public abstract class EMSNotationModelServerAccess extends EMSModelServerAccess 
     * Change Bounds
     */
    public CompletableFuture<Response<Boolean>> changeBounds(final Map<Shape, ElementAndBounds> changeBoundsMap) {
-      CCompoundCommand compoundCommand = CCommandFactory.eINSTANCE.createCompoundCommand();
-      compoundCommand.setType(ChangeBoundsCommandContribution.TYPE);
-      changeBoundsMap.forEach((shape, elementAndBounds) -> {
-         CCommand changeBoundsCommand = ChangeBoundsCommandContribution.create(shape.getSemanticElement().getUri(),
-            elementAndBounds.getNewPosition(), elementAndBounds.getNewSize());
-         compoundCommand.getCommands().add(changeBoundsCommand);
-      });
+      CCompoundCommand compoundCommand = ChangeBoundsCommandContribution.create(changeBoundsMap);
       return this.edit(compoundCommand);
+   }
+
+   public CompletableFuture<Response<Boolean>> changeBounds(final Shape shape, final ElementAndBounds changedBounds) {
+      CCommand changeBoundsCommand = ChangeBoundsCommandContribution.create(shape.getSemanticElement().getUri(),
+         changedBounds.getNewPosition(), changedBounds.getNewSize());
+      return this.edit(changeBoundsCommand);
+   }
+
+   public CompletableFuture<Response<Boolean>> changePosition(final Shape shape, final GPoint position) {
+      CCommand changePositionCommand = ChangeBoundsCommandContribution.create(shape.getSemanticElement().getUri(),
+         position);
+      return this.edit(changePositionCommand);
+   }
+
+   public CompletableFuture<Response<Boolean>> changeSize(final Shape shape, final GDimension size) {
+      CCommand changeSizeCommand = ChangeBoundsCommandContribution.create(shape.getSemanticElement().getUri(), size);
+      return this.edit(changeSizeCommand);
    }
 
    /*

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/META-INF/MANIFEST.MF
@@ -17,6 +17,7 @@ Export-Package: org.eclipse.emfcloud.modelserver.glsp.notation,
  org.eclipse.emfcloud.modelserver.glsp.notation.commands.util
 Require-Bundle: org.eclipse.emf.ecore,
  org.eclipse.glsp.graph;bundle-version="0.9.0",
+ org.eclipse.glsp.server;bundle-version="0.9.0",
  org.eclipse.emfcloud.modelserver.common;bundle-version="0.7.0",
  org.eclipse.emfcloud.modelserver.edit;bundle-version="0.7.0",
  org.eclipse.emfcloud.modelserver.emf;bundle-version="0.7.0",

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/pom.xml
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/pom.xml
@@ -78,6 +78,11 @@
 					<version>${glsp.version}</version>
 				</dependency>
 				<dependency>
+					<groupId>org.eclipse.glsp</groupId>
+					<artifactId>org.eclipse.glsp.server</artifactId>
+					<version>${glsp.version}</version>
+				</dependency>
+				<dependency>
 					<groupId>org.eclipse.emf</groupId>
 					<artifactId>org.eclipse.emf.edit</artifactId>
 					<version>${emf.edit.version}</version>

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/src/org/eclipse/emfcloud/modelserver/glsp/notation/commands/ChangeBoundsCommand.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/src/org/eclipse/emfcloud/modelserver/glsp/notation/commands/ChangeBoundsCommand.java
@@ -31,10 +31,24 @@ public class ChangeBoundsCommand extends NotationElementCommand {
       this.shape = NotationCommandUtil.getNotationElement(modelUri, domain, semanticProxyUri, Shape.class);
    }
 
+   public ChangeBoundsCommand(final EditingDomain domain, final URI modelUri, final String semanticProxyUri,
+      final GPoint shapePosition) {
+      this(domain, modelUri, semanticProxyUri, shapePosition, null);
+   }
+
+   public ChangeBoundsCommand(final EditingDomain domain, final URI modelUri, final String semanticProxyUri,
+      final GDimension shapeSize) {
+      this(domain, modelUri, semanticProxyUri, null, shapeSize);
+   }
+
    @Override
    protected void doExecute() {
-      shape.setPosition(shapePosition);
-      shape.setSize(shapeSize);
+      if (this.shapePosition != null) {
+         shape.setPosition(shapePosition);
+      }
+      if (this.shapeSize != null) {
+         shape.setSize(shapeSize);
+      }
    }
 
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/src/org/eclipse/emfcloud/modelserver/glsp/notation/commands/contribution/ChangeBoundsCommandContribution.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/src/org/eclipse/emfcloud/modelserver/glsp/notation/commands/contribution/ChangeBoundsCommandContribution.java
@@ -10,6 +10,9 @@
  ********************************************************************************/
 package org.eclipse.emfcloud.modelserver.glsp.notation.commands.contribution;
 
+import java.util.Map;
+
+import org.eclipse.emf.common.command.Command;
 import org.eclipse.emf.common.command.CompoundCommand;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.edit.domain.EditingDomain;
@@ -17,19 +20,26 @@ import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.command.CCommandFactory;
 import org.eclipse.emfcloud.modelserver.command.CCompoundCommand;
 import org.eclipse.emfcloud.modelserver.common.codecs.DecodingException;
+import org.eclipse.emfcloud.modelserver.glsp.notation.Shape;
 import org.eclipse.emfcloud.modelserver.glsp.notation.commands.ChangeBoundsCommand;
 import org.eclipse.emfcloud.modelserver.glsp.notation.commands.util.NotationCommandUtil;
 import org.eclipse.glsp.graph.GDimension;
 import org.eclipse.glsp.graph.GPoint;
+import org.eclipse.glsp.server.types.ElementAndBounds;
 
 public class ChangeBoundsCommandContribution extends NotationCommandContribution {
 
    public static final String TYPE = "changeBounds";
 
-   public static CCommand create(final String semanticUri, final GPoint position, final GDimension size) {
+   protected static CCommand create(final String semanticUri) {
       CCommand changeBoundsCommand = CCommandFactory.eINSTANCE.createCommand();
       changeBoundsCommand.setType(TYPE);
       changeBoundsCommand.getProperties().put(SEMANTIC_PROXI_URI, semanticUri);
+      return changeBoundsCommand;
+   }
+
+   public static CCommand create(final String semanticUri, final GPoint position, final GDimension size) {
+      CCommand changeBoundsCommand = create(semanticUri);
       changeBoundsCommand.getProperties().put(POSITION_X, String.valueOf(position.getX()));
       changeBoundsCommand.getProperties().put(POSITION_Y, String.valueOf(position.getY()));
       changeBoundsCommand.getProperties().put(HEIGHT, String.valueOf(size.getHeight()));
@@ -37,25 +47,68 @@ public class ChangeBoundsCommandContribution extends NotationCommandContribution
       return changeBoundsCommand;
    }
 
+   public static CCommand create(final String semanticUri, final GPoint position) {
+      CCommand changeBoundsCommand = create(semanticUri);
+      changeBoundsCommand.getProperties().put(POSITION_X, String.valueOf(position.getX()));
+      changeBoundsCommand.getProperties().put(POSITION_Y, String.valueOf(position.getY()));
+      return changeBoundsCommand;
+   }
+
+   public static CCommand create(final String semanticUri, final GDimension size) {
+      CCommand changeBoundsCommand = create(semanticUri);
+      changeBoundsCommand.getProperties().put(HEIGHT, String.valueOf(size.getHeight()));
+      changeBoundsCommand.getProperties().put(WIDTH, String.valueOf(size.getWidth()));
+      return changeBoundsCommand;
+   }
+
+   public static CCompoundCommand create(final Map<Shape, ElementAndBounds> changeBoundsMap) {
+      CCompoundCommand compoundCommand = CCommandFactory.eINSTANCE.createCompoundCommand();
+      compoundCommand.setType(ChangeBoundsCommandContribution.TYPE);
+      changeBoundsMap.forEach((shape, elementAndBounds) -> {
+         CCommand changeBoundsCommand = ChangeBoundsCommandContribution.create(shape.getSemanticElement().getUri(),
+            elementAndBounds.getNewPosition(), elementAndBounds.getNewSize());
+         compoundCommand.getCommands().add(changeBoundsCommand);
+      });
+      return compoundCommand;
+   }
+
    @Override
-   protected CompoundCommand toServer(final URI modelUri, final EditingDomain domain, final CCommand command)
+   protected Command toServer(final URI modelUri, final EditingDomain domain, final CCommand command)
       throws DecodingException {
 
-      CompoundCommand changeBoundsCommand = new CompoundCommand();
       if (command instanceof CCompoundCommand) {
+         CompoundCommand changeBoundsCommand = new CompoundCommand();
 
          ((CCompoundCommand) command).getCommands().forEach(cmd -> {
             String semanticProxyUri = cmd.getProperties().get(SEMANTIC_PROXI_URI);
-            GPoint elementPosition = NotationCommandUtil.getGPoint(
-               cmd.getProperties().get(POSITION_X), cmd.getProperties().get(POSITION_Y));
-            GDimension elementSize = NotationCommandUtil.getGDimension(
-               cmd.getProperties().get(WIDTH), cmd.getProperties().get(HEIGHT));
-
+            GPoint elementPosition = getElementPosition(command);
+            GDimension elementSize = getElementSize(command);
             changeBoundsCommand
                .append(new ChangeBoundsCommand(domain, modelUri, semanticProxyUri, elementPosition, elementSize));
          });
+         return changeBoundsCommand;
       }
-      return changeBoundsCommand;
+
+      String semanticProxyUri = command.getProperties().get(SEMANTIC_PROXI_URI);
+      GPoint elementPosition = getElementPosition(command);
+      GDimension elementSize = getElementSize(command);
+      return new ChangeBoundsCommand(domain, modelUri, semanticProxyUri, elementPosition, elementSize);
+   }
+
+   protected GPoint getElementPosition(final CCommand command) {
+      if (command.getProperties().containsKey(POSITION_X) && command.getProperties().containsKey(POSITION_Y)) {
+         return NotationCommandUtil.getGPoint(command.getProperties().get(POSITION_X),
+            command.getProperties().get(POSITION_Y));
+      }
+      return null;
+   }
+
+   protected GDimension getElementSize(final CCommand command) {
+      if (command.getProperties().containsKey(WIDTH) && command.getProperties().containsKey(HEIGHT)) {
+         return NotationCommandUtil.getGDimension(
+            command.getProperties().get(WIDTH), command.getProperties().get(HEIGHT));
+      }
+      return null;
    }
 
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/src/org/eclipse/emfcloud/modelserver/glsp/notation/commands/contribution/NotationCommandContribution.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/src/org/eclipse/emfcloud/modelserver/glsp/notation/commands/contribution/NotationCommandContribution.java
@@ -19,6 +19,6 @@ public abstract class NotationCommandContribution extends BasicCommandContributi
    public static final String POSITION_X = "positionX";
    public static final String POSITION_Y = "positionY";
    public static final String HEIGHT = "height";
-   public static final String WIDTH = "weight";
+   public static final String WIDTH = "width";
 
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/src/org/eclipse/emfcloud/modelserver/glsp/notation/commands/util/NotationCommandUtil.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.notation.model/src/org/eclipse/emfcloud/modelserver/glsp/notation/commands/util/NotationCommandUtil.java
@@ -34,10 +34,10 @@ public final class NotationCommandUtil {
       return gPoint;
    }
 
-   public static GDimension getGDimension(final String height, final String width) {
+   public static GDimension getGDimension(final String width, final String height) {
       GDimension gDimension = GraphUtil.dimension(
-         height.isEmpty() ? 0.0d : Double.parseDouble(height),
-         width.isEmpty() ? 0.0d : Double.parseDouble(width));
+         height.isEmpty() ? 0.0d : Double.parseDouble(width),
+         width.isEmpty() ? 0.0d : Double.parseDouble(height));
       return gDimension;
    }
 


### PR DESCRIPTION
- Extend ChangeBoundsCommand to accept size argument, position argument or both
  - Extend command contribution and model server access accordingly
- Fix mixed up width/height setting in NotationCommandUtil

Fixes #6 