### PR TITLE
#17 Improve Thread management

### DIFF
--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSGLSPModule.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSGLSPModule.java
@@ -14,6 +14,7 @@ import org.eclipse.emfcloud.modelserver.glsp.actions.handlers.EMSOperationAction
 import org.eclipse.emfcloud.modelserver.glsp.actions.handlers.EMSRedoActionHandler;
 import org.eclipse.emfcloud.modelserver.glsp.actions.handlers.EMSSaveModelActionHandler;
 import org.eclipse.emfcloud.modelserver.glsp.actions.handlers.EMSUndoActionHandler;
+import org.eclipse.emfcloud.modelserver.glsp.actions.handlers.EMSRefreshModelActionHandler;
 import org.eclipse.emfcloud.modelserver.glsp.layout.EMSLayoutEngine;
 import org.eclipse.glsp.server.actions.ActionHandler;
 import org.eclipse.glsp.server.actions.SaveModelActionHandler;
@@ -33,6 +34,7 @@ public abstract class EMSGLSPModule extends GModelJsonDiagramModule {
       bindings.remove(UndoRedoActionHandler.class);
       bindings.add(EMSUndoActionHandler.class);
       bindings.add(EMSRedoActionHandler.class);
+      bindings.add(EMSRefreshModelActionHandler.class);
    }
 
    @Override

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/EMSRefreshModelAction.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/EMSRefreshModelAction.java
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.glsp.actions;
+
+import org.eclipse.glsp.server.actions.Action;
+
+/**
+ * An action to trigger the refresh of the model from the ModelServer,
+ * after we receive an update (incremental or full).
+ */
+public class EMSRefreshModelAction extends Action {
+
+   public static final String KIND = "ems.refresh";
+
+   public EMSRefreshModelAction() {
+      super(KIND);
+   }
+
+}

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRedoActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRedoActionHandler.java
@@ -11,6 +11,10 @@
 package org.eclipse.emfcloud.modelserver.glsp.actions.handlers;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
@@ -26,11 +30,41 @@ public class EMSRedoActionHandler extends EMSBasicActionHandler<RedoAction, EMSM
    public List<Action> executeAction(final RedoAction action, final EMSModelState modelState,
       final EMSModelServerAccess modelServerAccess) {
 
-      modelServerAccess.redo().thenAccept(response -> {
-         if (!response.body()) {
-            LOGGER.warn("Cannot redo.");
+      CompletableFuture<Void> result = modelServerAccess.redo().thenAccept(response -> {
+         int status = response.getStatusCode();
+         switch (status) {
+            case 200: // OK
+            case 202: // Not redoable
+               return;
+            default:
+               // Typically error 500: ModelServer error
+               LOGGER.error("Invalid redo response: " + response.getStatusCode());
+               return;
          }
       });
+
+      // Make sure we wait for the redo result before proceeding with more actions
+      // Don't block forever, though.
+      // Note: this is especially important as the moment, because the ModelServer itself
+      // isn't thread safe. If we send multiple parallel redo requests, it may try to handle
+      // more than one at the same time, causing crashes. But even with a thread-safe model server,
+      // it's a good idea to wait a bit to make sure we're in a consistent state before handling
+      // more actions.
+      int maxTries = 5;
+      for (int i = 0; i < maxTries; i++) {
+         try {
+            result.get(1, TimeUnit.SECONDS);
+         } catch (TimeoutException e) {
+            LOGGER.warn("Redo action didn't complete in " + (i + 1) + "s");
+         } catch (InterruptedException e) {
+            LOGGER.error("Interrupted", e);
+            Thread.currentThread().interrupt();
+            break;
+         } catch (ExecutionException e) {
+            LOGGER.error("Failed to redo", e);
+            break;
+         }
+      }
 
       return none();
    }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRefreshModelActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRefreshModelActionHandler.java
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (c) 2021 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.glsp.actions.handlers;
+
+import java.util.List;
+
+import org.eclipse.emfcloud.modelserver.glsp.actions.EMSRefreshModelAction;
+import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
+import org.eclipse.glsp.server.actions.AbstractActionHandler;
+import org.eclipse.glsp.server.actions.Action;
+import org.eclipse.glsp.server.features.core.model.ModelSubmissionHandler;
+
+import com.google.inject.Inject;
+
+/**
+ * Handles model updates with an ActionHandler, to make sure we're in a thread-safe context.
+ */
+public class EMSRefreshModelActionHandler extends AbstractActionHandler<EMSRefreshModelAction> {
+
+   @Inject
+   protected ModelSubmissionHandler submissionHandler;
+
+   @Inject
+   protected EMSModelState modelState;
+
+   @Override
+   protected List<Action> executeAction(final EMSRefreshModelAction actualAction) {
+      // reload models
+      modelState.loadSourceModels();
+      // refresh GModelRoot
+      return submissionHandler.submitModel();
+   }
+
+}

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/model/EMSSubscriptionListener.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/model/EMSSubscriptionListener.java
@@ -16,14 +16,14 @@ import org.apache.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emfcloud.modelserver.client.XmiToEObjectSubscriptionListener;
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
+import org.eclipse.emfcloud.modelserver.glsp.actions.EMSRefreshModelAction;
 import org.eclipse.glsp.server.actions.ActionDispatcher;
 import org.eclipse.glsp.server.actions.SetDirtyStateAction;
 import org.eclipse.glsp.server.features.core.model.ModelSubmissionHandler;
-import org.eclipse.glsp.server.features.core.model.RequestBoundsAction;
 
 public class EMSSubscriptionListener extends XmiToEObjectSubscriptionListener {
 
-   private static Logger LOGGER = Logger.getLogger(EMSSubscriptionListener.class.getSimpleName());
+   private static final Logger LOGGER = Logger.getLogger(EMSSubscriptionListener.class.getSimpleName());
 
    protected final ActionDispatcher actionDispatcher;
    protected final EMSModelState modelState;
@@ -49,12 +49,7 @@ public class EMSSubscriptionListener extends XmiToEObjectSubscriptionListener {
    }
 
    protected void refresh() {
-      // reload models
-      modelState.loadSourceModels();
-      // refresh GModelRoot
-      submissionHandler.submitModel();
-      // requestboundsaction in submissionhandler not enough?
-      actionDispatcher.dispatch(new RequestBoundsAction(modelState.getRoot()));
+      actionDispatcher.dispatch(new EMSRefreshModelAction());
    }
 
    @Override

--- a/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.target
+++ b/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.target
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="EMF.cloud Model Server GLSP Integration Targetplatform" sequenceNumber="1637147013">
+<target name="EMF.cloud Model Server GLSP Integration Targetplatform" sequenceNumber="1637573334">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.glsp.feature.feature.group" version="0.9.0.202111041528"/>


### PR DESCRIPTION
- Handle model updates via the GLSP ActionDispatcher, to make sure model updates happen in the correct thread
- Wait for undo/redo requests to complete before accepting the next action(s) in the GLSP ActionDispatcher (Note: this was required because of eclipse-emfcloud/emfcloud-modelserver/issues/135, but if that issue is fixed, it should be fine: the model-server should no longer be able to process multiple undo or redo requests in parallel).

With these 2 fixes (ModelServer & GLSP-ModelServer), we're a lot closer to thread-safety. However, there may still be one case to handle: undo(), edit() and other model server methods do not return an update or the new model. Instead, we will receive (at some point) a model update via the `EMSSubscriptionListener`. Since this is asynchronous, we may start processing the next GLSP Action before we receive the updated model. In most cases, this shouldn't really matter (Because e.g. for Undo and Redo, GLSP won't rely on the current state of the model to determine how to execute the next action), but for GLSP Actions (Such as Create, Move, Reparent...), the GLSP Server might use an outdated version of the model to initialize the next command.

So we may have 3 versions of the model, that are not always in sync: the one from the ModelServer (reference, always correct), the one from GLSP (may be outdated while a command is executing, because we didn't receive the notification from the SubscriptionListener yet), and the one from the Client (Same thing). Both the GLSP Client and the GLSP Server may keep sending actions while they use this outdated version of the model.