### PR TITLE
#20#23 Update to GLSP 0.9.0 release version

### DIFF
--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSGLSPModule.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSGLSPModule.java
@@ -23,7 +23,6 @@ import org.eclipse.glsp.server.di.GModelJsonDiagramModule;
 import org.eclipse.glsp.server.di.MultiBinding;
 import org.eclipse.glsp.server.features.undoredo.UndoRedoActionHandler;
 import org.eclipse.glsp.server.layout.LayoutEngine;
-import org.eclipse.glsp.server.model.GModelState;
 import org.eclipse.glsp.server.operations.OperationActionHandler;
 
 public abstract class EMSGLSPModule extends GModelJsonDiagramModule {
@@ -50,7 +49,7 @@ public abstract class EMSGLSPModule extends GModelJsonDiagramModule {
    }
 
    @Override
-   protected Class<? extends GModelState> bindGModelState() {
+   protected Class<? extends EMSModelState> bindGModelState() {
       return EMSModelState.class;
    }
 

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSActionHandler.java
@@ -13,13 +13,12 @@ package org.eclipse.emfcloud.modelserver.glsp.actions.handlers;
 import java.util.List;
 
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
-import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.actions.ActionHandler;
 
-public interface EMSActionHandler<T extends Action, U extends EMSModelState, V extends EMSModelServerAccess>
+public interface EMSActionHandler<T extends Action, U extends EMSModelServerAccess>
    extends ActionHandler {
 
-   List<Action> executeAction(T action, U modelState, V modelServerAccess);
+   List<Action> executeAction(T action, U modelServerAccess);
 
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSBasicActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSBasicActionHandler.java
@@ -22,18 +22,16 @@ import org.eclipse.glsp.server.model.GModelState;
 import com.google.inject.Inject;
 
 @SuppressWarnings("restriction")
-public abstract class EMSBasicActionHandler<T extends Action, U extends EMSModelState, V extends EMSModelServerAccess>
-   extends AbstractActionHandler<T> implements EMSActionHandler<T, U, V> {
+public abstract class EMSBasicActionHandler<T extends Action, U extends EMSModelServerAccess>
+   extends AbstractActionHandler<T> implements EMSActionHandler<T, U> {
 
-   protected final Class<U> modelStateType;
-   protected final Class<V> modelServerAccessType;
+   protected final Class<U> modelServerAccessType;
 
    @Inject
    protected GModelState gModelState;
 
    public EMSBasicActionHandler() {
       super();
-      this.modelStateType = deriveModelStateType();
       this.modelServerAccessType = deriveModelServerAccessType();
    }
 
@@ -45,23 +43,16 @@ public abstract class EMSBasicActionHandler<T extends Action, U extends EMSModel
    }
 
    @SuppressWarnings("unchecked")
-   protected Class<U> deriveModelStateType() {
+   protected Class<U> deriveModelServerAccessType() {
       return (Class<U>) (GenericsUtil.getParametrizedType(getClass(), EMSBasicActionHandler.class))
          .getActualTypeArguments()[1];
-   }
-
-   @SuppressWarnings("unchecked")
-   protected Class<V> deriveModelServerAccessType() {
-      return (Class<V>) (GenericsUtil.getParametrizedType(getClass(), EMSBasicActionHandler.class))
-         .getActualTypeArguments()[2];
    }
 
    @Override
    public List<Action> executeAction(final T actualAction) {
       if (handles(actualAction)) {
          EMSModelServerAccess modelServerAccess = EMSModelState.getModelServerAccess(gModelState);
-         return executeAction(actionType.cast(actualAction), modelStateType.cast(gModelState),
-            modelServerAccessType.cast(modelServerAccess));
+         return executeAction(actionType.cast(actualAction), modelServerAccessType.cast(modelServerAccess));
       }
       return none();
    }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSBasicActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSBasicActionHandler.java
@@ -57,4 +57,6 @@ public abstract class EMSBasicActionHandler<T extends Action, U extends EMSModel
       return none();
    }
 
+   protected EMSModelState getEMSModelState() { return EMSModelState.getModelState(gModelState); }
+
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRedoActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRedoActionHandler.java
@@ -18,16 +18,15 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
-import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.features.undoredo.RedoAction;
 
-public class EMSRedoActionHandler extends EMSBasicActionHandler<RedoAction, EMSModelState, EMSModelServerAccess> {
+public class EMSRedoActionHandler extends EMSBasicActionHandler<RedoAction, EMSModelServerAccess> {
 
    private static final Logger LOGGER = Logger.getLogger(EMSRedoActionHandler.class.getSimpleName());
 
    @Override
-   public List<Action> executeAction(final RedoAction action, final EMSModelState modelState,
+   public List<Action> executeAction(final RedoAction action,
       final EMSModelServerAccess modelServerAccess) {
 
       CompletableFuture<Void> result = modelServerAccess.redo().thenAccept(response -> {

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRefreshModelActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRefreshModelActionHandler.java
@@ -17,23 +17,29 @@ import org.eclipse.emfcloud.modelserver.glsp.actions.EMSRefreshModelAction;
 import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.features.core.model.ModelSubmissionHandler;
+import org.eclipse.glsp.server.model.GModelState;
+import org.eclipse.glsp.server.types.GLSPServerException;
 
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
 /**
  * Handles model updates with an ActionHandler, to make sure we're in a thread-safe context.
  */
 public class EMSRefreshModelActionHandler
-   extends EMSBasicActionHandler<EMSRefreshModelAction, EMSModelState, EMSModelServerAccess> {
+   extends EMSBasicActionHandler<EMSRefreshModelAction, EMSModelServerAccess> {
 
    @Inject
    protected ModelSubmissionHandler submissionHandler;
+   @Inject
+   protected GModelState modelState;
 
    @Override
-   public List<Action> executeAction(final EMSRefreshModelAction action, final EMSModelState modelState,
+   public List<Action> executeAction(final EMSRefreshModelAction action,
       final EMSModelServerAccess modelServerAccess) {
+      EMSModelState emsModelState = EMSModelState.getModelState(modelState);
       // reload models
-      modelState.loadSourceModels();
+      emsModelState.loadSourceModels();
       // refresh GModelRoot
       return submissionHandler.submitModel();
    }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRefreshModelActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRefreshModelActionHandler.java
@@ -14,14 +14,10 @@ import java.util.List;
 
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
 import org.eclipse.emfcloud.modelserver.glsp.actions.EMSRefreshModelAction;
-import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.features.core.model.ModelSubmissionHandler;
-import org.eclipse.glsp.server.model.GModelState;
-import org.eclipse.glsp.server.types.GLSPServerException;
 
 import com.google.inject.Inject;
-import com.google.inject.name.Named;
 
 /**
  * Handles model updates with an ActionHandler, to make sure we're in a thread-safe context.
@@ -31,15 +27,12 @@ public class EMSRefreshModelActionHandler
 
    @Inject
    protected ModelSubmissionHandler submissionHandler;
-   @Inject
-   protected GModelState modelState;
 
    @Override
    public List<Action> executeAction(final EMSRefreshModelAction action,
       final EMSModelServerAccess modelServerAccess) {
-      EMSModelState emsModelState = EMSModelState.getModelState(modelState);
       // reload models
-      emsModelState.loadSourceModels();
+      getEMSModelState().loadSourceModels();
       // refresh GModelRoot
       return submissionHandler.submitModel();
    }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSSaveModelActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSSaveModelActionHandler.java
@@ -13,17 +13,15 @@ package org.eclipse.emfcloud.modelserver.glsp.actions.handlers;
 import java.util.List;
 
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
-import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.actions.SaveModelAction;
 import org.eclipse.glsp.server.types.GLSPServerException;
 
 public class EMSSaveModelActionHandler
-   extends EMSBasicActionHandler<SaveModelAction, EMSModelState, EMSModelServerAccess> {
+   extends EMSBasicActionHandler<SaveModelAction, EMSModelServerAccess> {
 
    @Override
-   public List<Action> executeAction(final SaveModelAction action, final EMSModelState modelState,
-      final EMSModelServerAccess modelServerAccess) {
+   public List<Action> executeAction(final SaveModelAction action, final EMSModelServerAccess modelServerAccess) {
 
       modelServerAccess.save().thenAccept(response -> {
          if (!response.body()) {

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSUndoActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSUndoActionHandler.java
@@ -18,18 +18,16 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.log4j.Logger;
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
-import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.features.undoredo.UndoAction;
 
 public class EMSUndoActionHandler
-   extends EMSBasicActionHandler<UndoAction, EMSModelState, EMSModelServerAccess> {
+   extends EMSBasicActionHandler<UndoAction, EMSModelServerAccess> {
 
    private static final Logger LOGGER = Logger.getLogger(EMSUndoActionHandler.class.getSimpleName());
 
    @Override
-   public List<Action> executeAction(final UndoAction action, final EMSModelState modelState,
-      final EMSModelServerAccess modelServerAccess) {
+   public List<Action> executeAction(final UndoAction action, final EMSModelServerAccess modelServerAccess) {
 
       CompletableFuture<Void> result = modelServerAccess.undo().thenAccept(response -> {
          int status = response.getStatusCode();

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/model/EMSModelSourceLoader.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/model/EMSModelSourceLoader.java
@@ -24,15 +24,12 @@ import org.eclipse.glsp.server.features.core.model.RequestModelAction;
 import org.eclipse.glsp.server.model.GModelState;
 import org.eclipse.glsp.server.types.GLSPServerException;
 import org.eclipse.glsp.server.utils.ClientOptionsUtil;
-import org.eclipse.glsp.server.utils.MapUtil;
 
 import com.google.inject.Inject;
 
 public abstract class EMSModelSourceLoader implements ModelSourceLoader {
 
    private static Logger LOGGER = Logger.getLogger(EMSModelSourceLoader.class.getSimpleName());
-
-   public static final String WORKSPACE_ROOT_OPTION = "workspaceRoot";
 
    @Inject
    protected ModelServerClientProvider modelServerClientProvider;
@@ -88,10 +85,7 @@ public abstract class EMSModelSourceLoader implements ModelSourceLoader {
    protected String getSourceURI(final Map<String, String> clientOptions) {
       String sourceURI = ClientOptionsUtil.getSourceUri(clientOptions)
          .orElseThrow(() -> new GLSPServerException("No source URI given to load model!"));
-      String workspaceRoot = MapUtil.getValue(clientOptions, WORKSPACE_ROOT_OPTION)
-         .orElseThrow(() -> new GLSPServerException("No workspace URI given to load model!"));
-
-      return sourceURI.replace(ClientOptionsUtil.adaptUri(workspaceRoot), "").replaceFirst("/", "");
+      return sourceURI;
    }
 
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationGLSPModule.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationGLSPModule.java
@@ -11,10 +11,10 @@
 package org.eclipse.emfcloud.modelserver.glsp.notation.integration;
 
 import org.eclipse.emfcloud.modelserver.glsp.EMSGLSPModule;
+import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
 import org.eclipse.emfcloud.modelserver.glsp.operations.handlers.EMSChangeBoundsOperationHandler;
 import org.eclipse.emfcloud.modelserver.glsp.operations.handlers.EMSLayoutOperationHandler;
 import org.eclipse.glsp.server.di.MultiBinding;
-import org.eclipse.glsp.server.model.GModelState;
 import org.eclipse.glsp.server.operations.OperationHandler;
 import org.eclipse.glsp.server.operations.gmodel.ChangeBoundsOperationHandler;
 import org.eclipse.glsp.server.operations.gmodel.LayoutOperationHandler;
@@ -29,7 +29,7 @@ public abstract class EMSNotationGLSPModule extends EMSGLSPModule {
    }
 
    @Override
-   protected Class<? extends GModelState> bindGModelState() {
+   protected Class<? extends EMSModelState> bindGModelState() {
       return EMSNotationModelState.class;
    }
 

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelState.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelState.java
@@ -11,10 +11,18 @@
 package org.eclipse.emfcloud.modelserver.glsp.notation.integration;
 
 import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
+import org.eclipse.glsp.server.model.GModelState;
 
 public abstract class EMSNotationModelState extends EMSModelState {
 
    @Override
    public abstract EMSNotationModelIndex getIndex();
+
+   public static EMSNotationModelState getModelState(final GModelState state) {
+      if (!(state instanceof EMSNotationModelState)) {
+         throw new IllegalArgumentException("Argument must be a EMSNotationModelState");
+      }
+      return ((EMSNotationModelState) state);
+   }
 
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSBasicCreateOperationHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSBasicCreateOperationHandler.java
@@ -16,27 +16,28 @@ import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
 import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
 import org.eclipse.glsp.server.internal.util.GenericsUtil;
 import org.eclipse.glsp.server.model.GModelState;
-import org.eclipse.glsp.server.operations.BasicCreateOperationHandler;
+import org.eclipse.glsp.server.operations.AbstractCreateOperationHandler;
 import org.eclipse.glsp.server.operations.CreateOperation;
 
 import com.google.common.collect.Lists;
+import com.google.inject.Inject;
 
 @SuppressWarnings("restriction")
-public abstract class EMSBasicCreateOperationHandler<T extends CreateOperation, U extends EMSModelState, V extends EMSModelServerAccess>
-   extends BasicCreateOperationHandler<T> implements EMSOperationHandler<T, U, V> {
+public abstract class EMSBasicCreateOperationHandler<T extends CreateOperation, U extends EMSModelServerAccess>
+   extends AbstractCreateOperationHandler<T> implements EMSOperationHandler<T, U> {
 
-   protected final Class<U> modelStateType;
-   protected final Class<V> modelServerAccessType;
+   @Inject
+   protected GModelState gModelState;
+
+   protected final Class<U> modelServerAccessType;
 
    public EMSBasicCreateOperationHandler(final String... elementTypeIds) {
       super(Lists.newArrayList(elementTypeIds));
-      this.modelStateType = deriveModelStateType();
       this.modelServerAccessType = deriveModelServerAccessType();
    }
 
    public EMSBasicCreateOperationHandler(final List<String> handledElementTypeIds) {
       super(handledElementTypeIds);
-      this.modelStateType = deriveModelStateType();
       this.modelServerAccessType = deriveModelServerAccessType();
    }
 
@@ -48,29 +49,17 @@ public abstract class EMSBasicCreateOperationHandler<T extends CreateOperation, 
    }
 
    @SuppressWarnings("unchecked")
-   protected Class<U> deriveModelStateType() {
+   protected Class<U> deriveModelServerAccessType() {
       return (Class<U>) (GenericsUtil.getParametrizedType(getClass(), EMSBasicCreateOperationHandler.class))
          .getActualTypeArguments()[1];
    }
 
-   @SuppressWarnings("unchecked")
-   protected Class<V> deriveModelServerAccessType() {
-      return (Class<V>) (GenericsUtil.getParametrizedType(getClass(), EMSBasicCreateOperationHandler.class))
-         .getActualTypeArguments()[2];
-   }
-
    @Override
-   public void executeOperation(final T operation, final GModelState gModelState) {
+   public void executeOperation(final T operation) {
       if (handles(operation)) {
-         EMSModelState modelState = getModelState(gModelState);
          EMSModelServerAccess modelServerAccess = getModelServerAccess(gModelState);
-         executeOperation(operationType.cast(operation), modelStateType.cast(modelState),
-            modelServerAccessType.cast(modelServerAccess));
+         executeOperation(operationType.cast(operation), modelServerAccessType.cast(modelServerAccess));
       }
-   }
-
-   protected EMSModelState getModelState(final GModelState gModelState) {
-      return EMSModelState.getModelState(gModelState);
    }
 
    protected EMSModelServerAccess getModelServerAccess(final GModelState gModelState) {

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSBasicCreateOperationHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSBasicCreateOperationHandler.java
@@ -57,13 +57,11 @@ public abstract class EMSBasicCreateOperationHandler<T extends CreateOperation, 
    @Override
    public void executeOperation(final T operation) {
       if (handles(operation)) {
-         EMSModelServerAccess modelServerAccess = getModelServerAccess(gModelState);
+         EMSModelServerAccess modelServerAccess = EMSModelState.getModelServerAccess(gModelState);
          executeOperation(operationType.cast(operation), modelServerAccessType.cast(modelServerAccess));
       }
    }
 
-   protected EMSModelServerAccess getModelServerAccess(final GModelState gModelState) {
-      return EMSModelState.getModelServerAccess(gModelState);
-   }
+   protected EMSModelState getEMSModelState() { return EMSModelState.getModelState(gModelState); }
 
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSBasicOperationHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSBasicOperationHandler.java
@@ -14,19 +14,22 @@ import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
 import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
 import org.eclipse.glsp.server.internal.util.GenericsUtil;
 import org.eclipse.glsp.server.model.GModelState;
-import org.eclipse.glsp.server.operations.BasicOperationHandler;
+import org.eclipse.glsp.server.operations.AbstractOperationHandler;
 import org.eclipse.glsp.server.operations.Operation;
 
-@SuppressWarnings("restriction")
-public abstract class EMSBasicOperationHandler<T extends Operation, U extends EMSModelState, V extends EMSModelServerAccess>
-   extends BasicOperationHandler<T> implements EMSOperationHandler<T, U, V> {
+import com.google.inject.Inject;
 
-   protected final Class<U> modelStateType;
-   protected final Class<V> modelServerAccessType;
+@SuppressWarnings("restriction")
+public abstract class EMSBasicOperationHandler<T extends Operation, U extends EMSModelServerAccess>
+   extends AbstractOperationHandler<T> implements EMSOperationHandler<T, U> {
+
+   @Inject
+   protected GModelState gModelState;
+
+   protected final Class<U> modelServerAccessType;
 
    public EMSBasicOperationHandler() {
       super();
-      this.modelStateType = deriveModelStateType();
       this.modelServerAccessType = deriveModelServerAccessType();
    }
 
@@ -38,29 +41,17 @@ public abstract class EMSBasicOperationHandler<T extends Operation, U extends EM
    }
 
    @SuppressWarnings("unchecked")
-   protected Class<U> deriveModelStateType() {
+   protected Class<U> deriveModelServerAccessType() {
       return (Class<U>) (GenericsUtil.getParametrizedType(getClass(), EMSBasicOperationHandler.class))
          .getActualTypeArguments()[1];
    }
 
-   @SuppressWarnings("unchecked")
-   protected Class<V> deriveModelServerAccessType() {
-      return (Class<V>) (GenericsUtil.getParametrizedType(getClass(), EMSBasicOperationHandler.class))
-         .getActualTypeArguments()[2];
-   }
-
    @Override
-   public void executeOperation(final T operation, final GModelState gModelState) {
+   public void executeOperation(final T operation) {
       if (handles(operation)) {
-         EMSModelState modelState = getModelState(gModelState);
          EMSModelServerAccess modelServerAccess = getModelServerAccess(gModelState);
-         executeOperation(operationType.cast(operation), modelStateType.cast(modelState),
-            modelServerAccessType.cast(modelServerAccess));
+         executeOperation(operationType.cast(operation), modelServerAccessType.cast(modelServerAccess));
       }
-   }
-
-   protected EMSModelState getModelState(final GModelState gModelState) {
-      return EMSModelState.getModelState(gModelState);
    }
 
    protected EMSModelServerAccess getModelServerAccess(final GModelState gModelState) {

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSBasicOperationHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSBasicOperationHandler.java
@@ -49,12 +49,10 @@ public abstract class EMSBasicOperationHandler<T extends Operation, U extends EM
    @Override
    public void executeOperation(final T operation) {
       if (handles(operation)) {
-         EMSModelServerAccess modelServerAccess = getModelServerAccess(gModelState);
+         EMSModelServerAccess modelServerAccess = EMSModelState.getModelServerAccess(gModelState);
          executeOperation(operationType.cast(operation), modelServerAccessType.cast(modelServerAccess));
       }
    }
 
-   protected EMSModelServerAccess getModelServerAccess(final GModelState gModelState) {
-      return EMSModelState.getModelServerAccess(gModelState);
-   }
+   protected EMSModelState getEMSModelState() { return EMSModelState.getModelState(gModelState); }
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSChangeBoundsOperationHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSChangeBoundsOperationHandler.java
@@ -16,22 +16,30 @@ import java.util.Map;
 import org.eclipse.emfcloud.modelserver.glsp.notation.Shape;
 import org.eclipse.emfcloud.modelserver.glsp.notation.integration.EMSNotationModelServerAccess;
 import org.eclipse.emfcloud.modelserver.glsp.notation.integration.EMSNotationModelState;
+import org.eclipse.glsp.server.model.GModelState;
 import org.eclipse.glsp.server.operations.ChangeBoundsOperation;
 import org.eclipse.glsp.server.types.ElementAndBounds;
 import org.eclipse.glsp.server.types.GLSPServerException;
 
+import com.google.inject.Inject;
+
 public class EMSChangeBoundsOperationHandler
-   extends EMSBasicOperationHandler<ChangeBoundsOperation, EMSNotationModelState, EMSNotationModelServerAccess> {
+   extends EMSBasicOperationHandler<ChangeBoundsOperation, EMSNotationModelServerAccess> {
+
+   @Inject
+   protected GModelState modelState;
 
    @Override
-   public void executeOperation(final ChangeBoundsOperation operation, final EMSNotationModelState modelState,
+   public void executeOperation(final ChangeBoundsOperation operation,
       final EMSNotationModelServerAccess modelServerAccess) {
 
+      EMSNotationModelState emsModelState = EMSNotationModelState.getModelState(modelState);
       Map<Shape, ElementAndBounds> changeBoundsMap = new HashMap<>();
       for (ElementAndBounds element : operation.getNewBounds()) {
-         modelState.getIndex().getNotation(element.getElementId(), Shape.class).ifPresent(notationElement -> {
-            changeBoundsMap.put(notationElement, element);
-         });
+         emsModelState.getIndex().getNotation(element.getElementId(), Shape.class)
+            .ifPresent(notationElement -> {
+               changeBoundsMap.put(notationElement, element);
+            });
       }
       modelServerAccess.changeBounds(changeBoundsMap).thenAccept(response -> {
          if (!response.body()) {

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSChangeBoundsOperationHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSChangeBoundsOperationHandler.java
@@ -16,24 +16,18 @@ import java.util.Map;
 import org.eclipse.emfcloud.modelserver.glsp.notation.Shape;
 import org.eclipse.emfcloud.modelserver.glsp.notation.integration.EMSNotationModelServerAccess;
 import org.eclipse.emfcloud.modelserver.glsp.notation.integration.EMSNotationModelState;
-import org.eclipse.glsp.server.model.GModelState;
 import org.eclipse.glsp.server.operations.ChangeBoundsOperation;
 import org.eclipse.glsp.server.types.ElementAndBounds;
 import org.eclipse.glsp.server.types.GLSPServerException;
 
-import com.google.inject.Inject;
-
 public class EMSChangeBoundsOperationHandler
    extends EMSBasicOperationHandler<ChangeBoundsOperation, EMSNotationModelServerAccess> {
-
-   @Inject
-   protected GModelState modelState;
 
    @Override
    public void executeOperation(final ChangeBoundsOperation operation,
       final EMSNotationModelServerAccess modelServerAccess) {
 
-      EMSNotationModelState emsModelState = EMSNotationModelState.getModelState(modelState);
+      EMSNotationModelState emsModelState = EMSNotationModelState.getModelState(gModelState);
       Map<Shape, ElementAndBounds> changeBoundsMap = new HashMap<>();
       for (ElementAndBounds element : operation.getNewBounds()) {
          emsModelState.getIndex().getNotation(element.getElementId(), Shape.class)

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSLayoutOperationHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSLayoutOperationHandler.java
@@ -18,7 +18,6 @@ import org.eclipse.glsp.server.diagram.DiagramConfiguration;
 import org.eclipse.glsp.server.features.core.model.ModelSubmissionHandler;
 import org.eclipse.glsp.server.layout.LayoutEngine;
 import org.eclipse.glsp.server.layout.ServerLayoutKind;
-import org.eclipse.glsp.server.model.GModelState;
 import org.eclipse.glsp.server.operations.LayoutOperation;
 
 import com.google.inject.Inject;
@@ -32,15 +31,13 @@ public class EMSLayoutOperationHandler
    protected ModelSubmissionHandler modelSubmissionHandler;
    @Inject
    protected DiagramConfiguration diagramConfiguration;
-   @Inject
-   protected GModelState modelState;
 
    @Override
    public void executeOperation(final LayoutOperation operation, final EMSNotationModelServerAccess modelServerAccess) {
-      EMSNotationModelState emsModelState = EMSNotationModelState.getModelState(modelState);
       if (diagramConfiguration.getLayoutKind() == ServerLayoutKind.MANUAL) {
          if (layoutEngine != null && layoutEngine instanceof EMSLayoutEngine) {
-            GModelElement layoutedRoot = ((EMSLayoutEngine) layoutEngine).layoutRoot(modelState);
+            GModelElement layoutedRoot = ((EMSLayoutEngine) layoutEngine).layoutRoot(gModelState);
+            EMSNotationModelState emsModelState = EMSNotationModelState.getModelState(gModelState);
             modelServerAccess.setLayout(emsModelState, layoutedRoot);
          }
       }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSLayoutOperationHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSLayoutOperationHandler.java
@@ -18,12 +18,13 @@ import org.eclipse.glsp.server.diagram.DiagramConfiguration;
 import org.eclipse.glsp.server.features.core.model.ModelSubmissionHandler;
 import org.eclipse.glsp.server.layout.LayoutEngine;
 import org.eclipse.glsp.server.layout.ServerLayoutKind;
+import org.eclipse.glsp.server.model.GModelState;
 import org.eclipse.glsp.server.operations.LayoutOperation;
 
 import com.google.inject.Inject;
 
 public class EMSLayoutOperationHandler
-   extends EMSBasicOperationHandler<LayoutOperation, EMSNotationModelState, EMSNotationModelServerAccess> {
+   extends EMSBasicOperationHandler<LayoutOperation, EMSNotationModelServerAccess> {
 
    @Inject
    protected LayoutEngine layoutEngine;
@@ -31,15 +32,16 @@ public class EMSLayoutOperationHandler
    protected ModelSubmissionHandler modelSubmissionHandler;
    @Inject
    protected DiagramConfiguration diagramConfiguration;
+   @Inject
+   protected GModelState modelState;
 
    @Override
-   public void executeOperation(final LayoutOperation operation, final EMSNotationModelState modelState,
-      final EMSNotationModelServerAccess modelServerAccess) {
-
+   public void executeOperation(final LayoutOperation operation, final EMSNotationModelServerAccess modelServerAccess) {
+      EMSNotationModelState emsModelState = EMSNotationModelState.getModelState(modelState);
       if (diagramConfiguration.getLayoutKind() == ServerLayoutKind.MANUAL) {
          if (layoutEngine != null && layoutEngine instanceof EMSLayoutEngine) {
             GModelElement layoutedRoot = ((EMSLayoutEngine) layoutEngine).layoutRoot(modelState);
-            modelServerAccess.setLayout(modelState, layoutedRoot);
+            modelServerAccess.setLayout(emsModelState, layoutedRoot);
          }
       }
    }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSOperationHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/operations/handlers/EMSOperationHandler.java
@@ -11,12 +11,11 @@
 package org.eclipse.emfcloud.modelserver.glsp.operations.handlers;
 
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
-import org.eclipse.emfcloud.modelserver.glsp.model.EMSModelState;
 import org.eclipse.glsp.server.operations.Operation;
 import org.eclipse.glsp.server.operations.OperationHandler;
 
-public interface EMSOperationHandler<T extends Operation, U extends EMSModelState, V extends EMSModelServerAccess>
+public interface EMSOperationHandler<T extends Operation, U extends EMSModelServerAccess>
    extends OperationHandler {
 
-   void executeOperation(T operation, U modelState, V modelServerAccess);
+   void executeOperation(T operation, U modelServerAccess);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 
 		<emf.ecore.version>2.24.0</emf.ecore.version>
 		<emf.edit.version>2.16.0</emf.edit.version>
-		<glsp.version>0.9.0-SNAPSHOT</glsp.version>
+		<glsp.version>0.9.0</glsp.version>
 		<modelserver.version>0.7.0-SNAPSHOT</modelserver.version>
 		<eclipse.core.runtime.version>3.7.0</eclipse.core.runtime.version>
 		<eclipse.core.resources.version>3.7.100</eclipse.core.resources.version>

--- a/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.target
+++ b/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.target
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="EMF.cloud Model Server GLSP Integration Targetplatform" sequenceNumber="1637673776">
+<target name="EMF.cloud Model Server GLSP Integration Targetplatform" sequenceNumber="1641394415">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.glsp.feature.feature.group" version="0.9.0.202111041528"/>
-      <unit id="org.eclipse.glsp.layout" version="0.9.0.202111041528"/>
-      <unit id="org.eclipse.glsp.graph" version="0.9.0.202111041528"/>
-      <repository location="https://download.eclipse.org/glsp/server/p2/nightly/0.9/0.9.0.202111041528/"/>
+      <unit id="org.eclipse.glsp.feature.feature.group" version="0.9.0"/>
+      <unit id="org.eclipse.glsp.layout" version="0.9.0"/>
+      <unit id="org.eclipse.glsp.graph" version="0.9.0"/>
+      <repository location="https://download.eclipse.org/glsp/server/p2/releases/0.9.0/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202111221314"/>
@@ -29,7 +29,7 @@
       <repository location="https://download.eclipse.org/elk/updates/releases/0.7.1/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emfcloud.emfjson-jackson" version="0.0.0"/>
+      <unit id="org.eclipse.emfcloud.emfjson-jackson" version="1.3.1.20210901085939"/>
       <repository location="https://download.eclipse.org/emfcloud/emfjson-jackson/p2/nightly/1.3/1.3.1.202109010859"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.tpd
+++ b/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.tpd
@@ -1,6 +1,6 @@
 target "EMF.cloud Model Server GLSP Integration Targetplatform" with source requirements
 
-location "https://download.eclipse.org/glsp/server/p2/nightly/0.9/0.9.0.202111041528/" {
+location "https://download.eclipse.org/glsp/server/p2/releases/0.9.0/" {
 	org.eclipse.glsp.feature.feature.group [0.9.0,1.0.0)
 	org.eclipse.glsp.layout [0.9.0,1.0.0)
 	org.eclipse.glsp.graph [0.9.0,1.0.0)
@@ -27,7 +27,7 @@ location "https://download.eclipse.org/elk/updates/releases/0.7.1/" {
 }
 
 location "https://download.eclipse.org/emfcloud/emfjson-jackson/p2/nightly/1.3/1.3.1.202109010859" {
-	org.eclipse.emfcloud.emfjson-jackson lazy
+	org.eclipse.emfcloud.emfjson-jackson [1.3.1,2.0.0)
 }
 
 location "https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.44.v20210927/" {


### PR DESCRIPTION
Fixes #20 Fix default getSourceUri in EMSModelSourceLoader
- Fix getSourceUri to return complete sourceUri instead of workspace relative Uri by default

Fixes #23 Update EMSBasicHandlers and update to GLSP 0.9.0. 
- Update dependency to GLSP 0.9.0 release version
- Improve EMSBasic(Action|Operation)Handlers by injecting EMSModelState and reduce generic Types
- Replace deprecated usage of BasicOperationHandler/BasicCreateOperationHandler with AbstractOperationHandler/AbstractCreateOperationHandler
