### PR TITLE
Update dependencies and ensure support for modelserver V1

### DIFF
--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/META-INF/MANIFEST.MF
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/META-INF/MANIFEST.MF
@@ -19,7 +19,9 @@ Require-Bundle: org.eclipse.glsp.server,
  org.eclipse.elk.alg.layered;bundle-version="0.7.0",
  org.eclipse.emf.ecore,
  org.eclipse.emfcloud.modelserver.glsp.notation.model,
- org.eclipse.emfcloud.modelserver.glsp.notation.commands
+ org.eclipse.emfcloud.modelserver.glsp.notation.commands,
+ org.apache.logging.log4j;bundle-version="2.17.1",
+ org.apache.log4j;bundle-version="1.2.19"
 Bundle-ClassPath: .
 Export-Package: org.eclipse.emfcloud.modelserver.glsp,
  org.eclipse.emfcloud.modelserver.glsp.actions,
@@ -29,4 +31,3 @@ Export-Package: org.eclipse.emfcloud.modelserver.glsp,
  org.eclipse.emfcloud.modelserver.glsp.model,
  org.eclipse.emfcloud.modelserver.glsp.notation.integration,
  org.eclipse.emfcloud.modelserver.glsp.operations.handlers
-Import-Package: org.apache.log4j;version="1.2.15"

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/pom.xml
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/pom.xml
@@ -76,6 +76,11 @@
 					<artifactId>org.eclipse.glsp.layout</artifactId>
 					<version>${glsp.version}</version>
 				</dependency>
+				<dependency>
+					<groupId>org.apache.logging.log4j</groupId>
+					<artifactId>log4j-core</artifactId>
+					<version>${apache.logging.log4j.version}</version>
+				</dependency>
 			</dependencies>
 
 		</profile>

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSGLSPServer.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSGLSPServer.java
@@ -18,9 +18,10 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.log4j.Logger;
-import org.eclipse.emfcloud.modelserver.client.ModelServerClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.emfcloud.modelserver.client.Response;
+import org.eclipse.emfcloud.modelserver.client.v1.ModelServerClientV1;
 import org.eclipse.emfcloud.modelserver.glsp.client.ModelServerClientProvider;
 import org.eclipse.glsp.server.protocol.DefaultGLSPServer;
 import org.eclipse.glsp.server.protocol.DisposeClientSessionParameters;
@@ -31,7 +32,7 @@ import com.google.inject.Inject;
 
 public class EMSGLSPServer extends DefaultGLSPServer {
 
-   private static Logger LOGGER = Logger.getLogger(EMSGLSPServer.class.getSimpleName());
+   private static Logger LOGGER = LogManager.getLogger(EMSGLSPServer.class.getSimpleName());
    private static final String TIMESTAMP_KEY = "timestamp";
    private static final String MODELSERVER_URL_KEY = "modelServerURL";
    private static final String MODEL_URI_KEY = "modelUri";
@@ -59,7 +60,7 @@ public class EMSGLSPServer extends DefaultGLSPServer {
       LOGGER.debug(String.format("[%s] Pinging modelserver", timestamp));
 
       try {
-         ModelServerClient client = createModelServerClient(modelServerURL);
+         ModelServerClientV1 client = createModelServerClient(modelServerURL);
          boolean alive = client.ping().thenApply(Response<Boolean>::body).get();
          if (alive) {
             modelServerClientProvider.setModelServerClient(client);
@@ -72,13 +73,13 @@ public class EMSGLSPServer extends DefaultGLSPServer {
       return completableResult;
    }
 
-   protected ModelServerClient createModelServerClient(final String modelServerURL) throws MalformedURLException {
-      return new ModelServerClient(modelServerURL);
+   protected ModelServerClientV1 createModelServerClient(final String modelServerURL) throws MalformedURLException {
+      return new ModelServerClientV1(modelServerURL);
    }
 
    @Override
    public CompletableFuture<Void> disposeClientSession(final DisposeClientSessionParameters params) {
-      Optional<ModelServerClient> modelServerClient = modelServerClientProvider.get();
+      Optional<ModelServerClientV1> modelServerClient = modelServerClientProvider.get();
       Optional<String> modelUri = MapUtil.getValue(params.getArgs(), MODEL_URI_KEY);
       if (modelServerClient.isPresent() && modelUri.isPresent()) {
          modelServerClient.get().unsubscribe(modelUri.get());

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSModelServerAccess.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSModelServerAccess.java
@@ -13,13 +13,14 @@ package org.eclipse.emfcloud.modelserver.glsp;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.common.util.URI;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emfcloud.modelserver.client.ModelServerClient;
-import org.eclipse.emfcloud.modelserver.client.ModelServerClientApi;
+import org.eclipse.emfcloud.modelserver.client.ModelServerClientApiV1;
 import org.eclipse.emfcloud.modelserver.client.NotificationSubscriptionListener;
 import org.eclipse.emfcloud.modelserver.client.Response;
+import org.eclipse.emfcloud.modelserver.client.v1.ModelServerClientV1;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.glsp.server.types.GLSPServerException;
 
@@ -27,17 +28,17 @@ import com.google.common.base.Preconditions;
 
 public class EMSModelServerAccess {
 
-   private static Logger LOGGER = Logger.getLogger(EMSModelServerAccess.class);
+   private static Logger LOGGER = LogManager.getLogger(EMSModelServerAccess.class);
 
    protected static final String FORMAT_XMI = "xmi";
 
    protected final URI baseSourceUri;
    protected String semanticFileExtension;
 
-   protected final ModelServerClient modelServerClient;
+   protected final ModelServerClientV1 modelServerClient;
    protected NotificationSubscriptionListener<EObject> subscriptionListener;
 
-   public EMSModelServerAccess(final String sourceURI, final ModelServerClient modelServerClient,
+   public EMSModelServerAccess(final String sourceURI, final ModelServerClientV1 modelServerClient,
       final String semanticFileExtension) {
       Preconditions.checkNotNull(modelServerClient);
       this.baseSourceUri = URI.createURI(sourceURI, true).trimFileExtension();
@@ -47,7 +48,7 @@ public class EMSModelServerAccess {
 
    public String getSemanticURI() { return baseSourceUri.appendFileExtension(this.semanticFileExtension).toString(); }
 
-   public ModelServerClientApi<EObject> getModelServerClient() { return modelServerClient; }
+   public ModelServerClientApiV1<EObject> getModelServerClient() { return modelServerClient; }
 
    public EObject getSemanticModel() {
       try {

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRedoActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSRedoActionHandler.java
@@ -16,14 +16,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.features.undoredo.RedoAction;
 
 public class EMSRedoActionHandler extends EMSBasicActionHandler<RedoAction, EMSModelServerAccess> {
 
-   private static final Logger LOGGER = Logger.getLogger(EMSRedoActionHandler.class.getSimpleName());
+   private static final Logger LOGGER = LogManager.getLogger(EMSRedoActionHandler.class.getSimpleName());
 
    @Override
    public List<Action> executeAction(final RedoAction action,

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSUndoActionHandler.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/actions/handlers/EMSUndoActionHandler.java
@@ -16,7 +16,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
 import org.eclipse.glsp.server.actions.Action;
 import org.eclipse.glsp.server.features.undoredo.UndoAction;
@@ -24,7 +25,7 @@ import org.eclipse.glsp.server.features.undoredo.UndoAction;
 public class EMSUndoActionHandler
    extends EMSBasicActionHandler<UndoAction, EMSModelServerAccess> {
 
-   private static final Logger LOGGER = Logger.getLogger(EMSUndoActionHandler.class.getSimpleName());
+   private static final Logger LOGGER = LogManager.getLogger(EMSUndoActionHandler.class.getSimpleName());
 
    @Override
    public List<Action> executeAction(final UndoAction action, final EMSModelServerAccess modelServerAccess) {

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/client/ModelServerClientProvider.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/client/ModelServerClientProvider.java
@@ -12,20 +12,20 @@ package org.eclipse.emfcloud.modelserver.glsp.client;
 
 import java.util.Optional;
 
-import org.eclipse.emfcloud.modelserver.client.ModelServerClient;
+import org.eclipse.emfcloud.modelserver.client.v1.ModelServerClientV1;
 
 import com.google.inject.Singleton;
 
 @Singleton
 public class ModelServerClientProvider {
 
-   private ModelServerClient modelServerClient;
+   private ModelServerClientV1 modelServerClient;
 
-   public Optional<ModelServerClient> get() {
+   public Optional<ModelServerClientV1> get() {
       return Optional.ofNullable(modelServerClient);
    }
 
-   public void setModelServerClient(final ModelServerClient modelServerClient) {
+   public void setModelServerClient(final ModelServerClientV1 modelServerClient) {
       this.modelServerClient = modelServerClient;
    }
 

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/model/EMSModelSourceLoader.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/model/EMSModelSourceLoader.java
@@ -13,8 +13,9 @@ package org.eclipse.emfcloud.modelserver.glsp.model;
 import java.util.Map;
 import java.util.Optional;
 
-import org.apache.log4j.Logger;
-import org.eclipse.emfcloud.modelserver.client.ModelServerClient;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.emfcloud.modelserver.client.v1.ModelServerClientV1;
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelServerAccess;
 import org.eclipse.emfcloud.modelserver.glsp.client.ModelServerClientProvider;
 import org.eclipse.glsp.server.actions.ActionDispatcher;
@@ -29,7 +30,7 @@ import com.google.inject.Inject;
 
 public abstract class EMSModelSourceLoader implements ModelSourceLoader {
 
-   private static Logger LOGGER = Logger.getLogger(EMSModelSourceLoader.class.getSimpleName());
+   private static Logger LOGGER = LogManager.getLogger(EMSModelSourceLoader.class.getSimpleName());
 
    @Inject
    protected ModelServerClientProvider modelServerClientProvider;
@@ -50,7 +51,7 @@ public abstract class EMSModelSourceLoader implements ModelSourceLoader {
          LOGGER.error("No source URI given to load source models");
          return;
       }
-      Optional<ModelServerClient> modelServerClient = modelServerClientProvider.get();
+      Optional<ModelServerClientV1> modelServerClient = modelServerClientProvider.get();
       if (modelServerClient.isEmpty()) {
          LOGGER.error("Connection to modelserver could not be initialized");
          return;
@@ -73,7 +74,7 @@ public abstract class EMSModelSourceLoader implements ModelSourceLoader {
    }
 
    public abstract EMSModelServerAccess createModelServerAccess(String sourceURI,
-      ModelServerClient modelServerClient);
+      ModelServerClientV1 modelServerClient);
 
    public abstract EMSModelState createModelState(GModelState gModelState);
 

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/model/EMSSubscriptionListener.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/model/EMSSubscriptionListener.java
@@ -12,7 +12,8 @@ package org.eclipse.emfcloud.modelserver.glsp.model;
 
 import java.util.Optional;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emfcloud.modelserver.client.XmiToEObjectSubscriptionListener;
 import org.eclipse.emfcloud.modelserver.command.CCommandExecutionResult;
@@ -23,7 +24,7 @@ import org.eclipse.glsp.server.features.core.model.ModelSubmissionHandler;
 
 public class EMSSubscriptionListener extends XmiToEObjectSubscriptionListener {
 
-   private static final Logger LOGGER = Logger.getLogger(EMSSubscriptionListener.class.getSimpleName());
+   private static final Logger LOGGER = LogManager.getLogger(EMSSubscriptionListener.class.getSimpleName());
 
    protected final ActionDispatcher actionDispatcher;
    protected final EMSModelState modelState;

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelServerAccess.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelServerAccess.java
@@ -16,10 +16,11 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.emfcloud.modelserver.client.ModelServerClient;
 import org.eclipse.emfcloud.modelserver.client.Response;
+import org.eclipse.emfcloud.modelserver.client.v1.ModelServerClientV1;
 import org.eclipse.emfcloud.modelserver.command.CCommand;
 import org.eclipse.emfcloud.modelserver.command.CCommandFactory;
 import org.eclipse.emfcloud.modelserver.command.CCompoundCommand;
@@ -42,9 +43,9 @@ public abstract class EMSNotationModelServerAccess extends EMSModelServerAccess 
 
    protected String notationFileExtension;
 
-   private static Logger LOGGER = Logger.getLogger(EMSNotationModelServerAccess.class);
+   private static Logger LOGGER = LogManager.getLogger(EMSNotationModelServerAccess.class);
 
-   public EMSNotationModelServerAccess(final String sourceURI, final ModelServerClient modelServerClient,
+   public EMSNotationModelServerAccess(final String sourceURI, final ModelServerClientV1 modelServerClient,
       final String semanticFileExtension, final String notationFileExtension) {
       super(sourceURI, modelServerClient, semanticFileExtension);
       this.notationFileExtension = notationFileExtension;

--- a/pom.xml
+++ b/pom.xml
@@ -82,14 +82,15 @@
 
 		<emf.ecore.version>2.24.0</emf.ecore.version>
 		<emf.edit.version>2.16.0</emf.edit.version>
-		<glsp.version>0.9.0</glsp.version>
+		<glsp.version>0.10.0-SNAPSHOT</glsp.version>
 		<modelserver.version>0.7.0-SNAPSHOT</modelserver.version>
 		<eclipse.core.runtime.version>3.7.0</eclipse.core.runtime.version>
 		<eclipse.core.resources.version>3.7.100</eclipse.core.resources.version>
 		<emf.common.version>2.23.0</emf.common.version>
 		<emf.ecore.change.version>2.14.0</emf.ecore.change.version>
-		<emf.transaction.version>1.4.0.201306111400</emf.transaction.version>
+		<emf.transaction.version>1.8.0.201405281451</emf.transaction.version>
 		<emf.validation.version>1.8.0.201405281429</emf.validation.version>
+		<apache.logging.log4j.version>2.17.1</apache.logging.log4j.version>
 	</properties>
 
 	<modules>

--- a/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.target
+++ b/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.target
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="EMF.cloud Model Server GLSP Integration Targetplatform" sequenceNumber="1641394415">
+<target name="EMF.cloud Model Server GLSP Integration Targetplatform" sequenceNumber="1646833931">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.glsp.feature.feature.group" version="0.9.0"/>
-      <unit id="org.eclipse.glsp.layout" version="0.9.0"/>
-      <unit id="org.eclipse.glsp.graph" version="0.9.0"/>
-      <repository location="https://download.eclipse.org/glsp/server/p2/releases/0.9.0/"/>
+      <unit id="org.eclipse.glsp.feature.feature.group" version="0.10.0.202203070850"/>
+      <unit id="org.eclipse.glsp.layout" version="0.10.0.202203070850"/>
+      <unit id="org.eclipse.glsp.graph" version="0.10.0.202203070850"/>
+      <repository location="https://download.eclipse.org/glsp/server/p2/nightly/0.10/0.10.0.202203070850"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202111221314"/>
-      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202111221314/"/>
+      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202203091127"/>
+      <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202203091127/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.1200.v20210527-0259"/>
-      <repository location="http://download.eclipse.org/releases/2021-06"/>
+      <unit id="org.eclipse.equinox.executable.feature.group" version="3.8.1500.v20220210-1108"/>
+      <repository location="http://download.eclipse.org/releases/2022-03"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.apache.commons.io" version="2.8.0.v20210415-0900"/>
-      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/"/>
+      <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.elk.core" version="0.7.1"/>
@@ -29,8 +29,8 @@
       <repository location="https://download.eclipse.org/elk/updates/releases/0.7.1/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emfcloud.emfjson-jackson" version="1.3.1.20210901085939"/>
-      <repository location="https://download.eclipse.org/emfcloud/emfjson-jackson/p2/nightly/1.3/1.3.1.202109010859"/>
+      <unit id="org.eclipse.emfcloud.emfjson-jackson" version="2.0.0"/>
+      <repository location="https://download.eclipse.org/emfcloud/emfjson-jackson/p2/releases/2.0.0/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.jetty.server" version="0.0.0"/>

--- a/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.tpd
+++ b/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.tpd
@@ -1,20 +1,20 @@
 target "EMF.cloud Model Server GLSP Integration Targetplatform" with source requirements
 
-location "https://download.eclipse.org/glsp/server/p2/releases/0.9.0/" {
-	org.eclipse.glsp.feature.feature.group [0.9.0,1.0.0)
-	org.eclipse.glsp.layout [0.9.0,1.0.0)
-	org.eclipse.glsp.graph [0.9.0,1.0.0)
+location "https://download.eclipse.org/glsp/server/p2/nightly/0.10/0.10.0.202203070850" {
+	org.eclipse.glsp.feature.feature.group [0.10.0,1.0.0)
+	org.eclipse.glsp.layout [0.10.0,1.0.0)
+	org.eclipse.glsp.graph [0.10.0,1.0.0)
 }
 
-location "https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202111221314/" {
+location "https://download.eclipse.org/emfcloud/modelserver/p2/nightly/0.7/0.7.0.202203091127/" {
 	org.eclipse.emfcloud.modelserver.feature.feature.group [0.7.0,1.0.0)
 }
 
-location "http://download.eclipse.org/releases/2021-06" {
+location "http://download.eclipse.org/releases/2022-03" {
 	org.eclipse.equinox.executable.feature.group
 }
 
-location "https://download.eclipse.org/tools/orbit/downloads/drops/R20210602031627/repository/" {
+location "https://download.eclipse.org/tools/orbit/downloads/drops/R20220302172233/repository/" {
 	// Transitive dependencies
 	org.apache.commons.io [2.6.0,3.0.0)
 }
@@ -26,8 +26,8 @@ location "https://download.eclipse.org/elk/updates/releases/0.7.1/" {
 	org.eclipse.elk.alg.layered
 }
 
-location "https://download.eclipse.org/emfcloud/emfjson-jackson/p2/nightly/1.3/1.3.1.202109010859" {
-	org.eclipse.emfcloud.emfjson-jackson [1.3.1,2.0.0)
+location "https://download.eclipse.org/emfcloud/emfjson-jackson/p2/releases/2.0.0/" {
+	org.eclipse.emfcloud.emfjson-jackson [2.0.0,3.0.0)
 }
 
 location "https://download.eclipse.org/jetty/updates/jetty-bundles-9.x/9.4.44.v20210927/" {


### PR DESCRIPTION
- Update modelserver dependency to latest 0.7.0 version
  - Adapt to changes and ensure V1 is still supported properly
- Update GLSP server to latest 0.10.0 version
- Update emfjson-jackson to 2.0.0 release version