### PR TITLE
GLSP-974: Use interface-injection for all subclasses of ModelState

### DIFF
--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSGLSPDiagramModule.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSGLSPDiagramModule.java
@@ -30,7 +30,6 @@ import org.eclipse.glsp.server.emf.idgen.AttributeIdGenerator;
 import org.eclipse.glsp.server.emf.notation.EMFSemanticIdConverter;
 import org.eclipse.glsp.server.features.core.model.RequestModelActionHandler;
 import org.eclipse.glsp.server.features.undoredo.UndoRedoActionHandler;
-import org.eclipse.glsp.server.model.GModelState;
 import org.eclipse.glsp.server.operations.CompoundOperationHandler;
 import org.eclipse.glsp.server.operations.OperationActionHandler;
 import org.eclipse.glsp.server.operations.OperationHandler;
@@ -81,14 +80,7 @@ public abstract class EMSGLSPDiagramModule extends DiagramModule {
 
    @Override
    protected Class<? extends EMSModelState> bindGModelState() {
-      return EMSModelState.class;
-   }
-
-   @Override
-   @SuppressWarnings("unchecked")
-   protected void configureGModelState(final Class<? extends GModelState> gmodelStateClass) {
-      super.configureGModelState(gmodelStateClass);
-      bind(EMSModelState.class).to((Class<? extends EMSModelState>) gmodelStateClass);
+      return EMSModelStateImpl.class;
    }
 
    @Override
@@ -123,6 +115,16 @@ public abstract class EMSGLSPDiagramModule extends DiagramModule {
    protected void configureOperationHandlers(final MultiBinding<OperationHandler<?>> bindings) {
       super.configureOperationHandlers(bindings);
       bindings.rebind(CompoundOperationHandler.class, EMSCompoundOperationHandler.class);
+   }
+
+   @Override
+   protected void configure() {
+      super.configure();
+      configureEMSModelState(bindGModelState());
+   }
+
+   protected void configureEMSModelState(final Class<? extends EMSModelState> modelState) {
+      bind(EMSModelState.class).to(modelState).in(Singleton.class);
    }
 
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSModelState.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSModelState.java
@@ -16,9 +16,9 @@ import org.eclipse.emf.ecore.EObject;
 import org.eclipse.glsp.server.emf.EMFModelState;
 
 public interface EMSModelState extends EMFModelState {
-   void setSemanticModel(final EObject semanticModel);
+   void setSemanticModel(EObject semanticModel);
 
    EObject getSemanticModel();
 
-   <T extends EObject> Optional<T> getSemanticModel(final Class<T> clazz);
+   <T extends EObject> Optional<T> getSemanticModel(Class<T> clazz);
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSModelState.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSModelState.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2023 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,52 +12,13 @@ package org.eclipse.emfcloud.modelserver.glsp;
 
 import java.util.Optional;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.eclipse.emf.ecore.EObject;
-import org.eclipse.glsp.graph.GModelIndex;
-import org.eclipse.glsp.graph.GModelRoot;
-import org.eclipse.glsp.server.emf.EMFModelIndex;
 import org.eclipse.glsp.server.emf.EMFModelState;
-import org.eclipse.glsp.server.emf.notation.EMFSemanticIdConverter;
-import org.eclipse.glsp.server.session.ClientSession;
 
-import com.google.inject.Inject;
+public interface EMSModelState extends EMFModelState {
+   void setSemanticModel(final EObject semanticModel);
 
-public class EMSModelState extends EMFModelState {
+   EObject getSemanticModel();
 
-   private static final Logger LOGGER = LogManager.getLogger(EMSModelState.class);
-
-   protected EObject semanticModel;
-
-   @Inject
-   protected EMSModelServerAccess modelServerAccess;
-   @Inject
-   protected EMFSemanticIdConverter semanticIdConverter;
-
-   @Override
-   protected GModelIndex getOrUpdateIndex(final GModelRoot newRoot) {
-      return EMFModelIndex.getOrCreate(getRoot(), semanticIdConverter);
-   }
-
-   public void setSemanticModel(final EObject semanticModel) { this.semanticModel = semanticModel; }
-
-   public EObject getSemanticModel() { return this.semanticModel; }
-
-   public <T extends EObject> Optional<T> getSemanticModel(final Class<T> clazz) {
-      return Optional.ofNullable(this.semanticModel).filter(clazz::isInstance).map(clazz::cast);
-   }
-
-   @Override
-   public void sessionDisposed(final ClientSession clientSession) {
-      if (this.semanticModel != null) {
-         this.semanticModel = null;
-         modelServerAccess.close().thenAccept(response -> {
-            LOGGER.warn("Error on disposing ClientSession: " + response.getMessage());
-         });
-         modelServerAccess.unsubscribe();
-      }
-      super.sessionDisposed(clientSession);
-   }
-
+   <T extends EObject> Optional<T> getSemanticModel(final Class<T> clazz);
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSModelStateImpl.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSModelStateImpl.java
@@ -1,0 +1,68 @@
+/********************************************************************************
+ * Copyright (c) 2021-2023 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.glsp;
+
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.glsp.graph.GModelIndex;
+import org.eclipse.glsp.graph.GModelRoot;
+import org.eclipse.glsp.server.emf.EMFModelIndex;
+import org.eclipse.glsp.server.emf.EMFModelStateImpl;
+import org.eclipse.glsp.server.emf.notation.EMFSemanticIdConverter;
+import org.eclipse.glsp.server.session.ClientSession;
+
+import com.google.inject.Inject;
+
+public class EMSModelStateImpl extends EMFModelStateImpl implements EMSModelState {
+
+   private static final Logger LOGGER = LogManager.getLogger(EMSModelStateImpl.class);
+
+   protected EObject semanticModel;
+
+   @Inject
+   protected EMSModelServerAccess modelServerAccess;
+   @Inject
+   protected EMFSemanticIdConverter semanticIdConverter;
+
+   @Override
+   protected GModelIndex getOrUpdateIndex(final GModelRoot newRoot) {
+      return EMFModelIndex.getOrCreate(getRoot(), semanticIdConverter);
+   }
+
+   @Override
+   public void setSemanticModel(final EObject semanticModel) { this.semanticModel = semanticModel; }
+
+   @Override
+   public EObject getSemanticModel() { return this.semanticModel; }
+
+   @Override
+   public <T extends EObject> Optional<T> getSemanticModel(final Class<T> clazz) {
+      return Optional.ofNullable(this.semanticModel).filter(clazz::isInstance).map(clazz::cast);
+   }
+
+   @Override
+   public void sessionDisposed(final ClientSession clientSession) {
+      if (this.semanticModel != null) {
+         this.semanticModel = null;
+         modelServerAccess.close().thenAccept(response -> {
+            if (!response.body()) {
+               LOGGER.warn("Error on disposing ClientSession: " + response.getMessage());
+            }
+         });
+         modelServerAccess.unsubscribe();
+      }
+      super.sessionDisposed(clientSession);
+   }
+
+}

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSModelStateImpl.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/EMSModelStateImpl.java
@@ -23,7 +23,9 @@ import org.eclipse.glsp.server.emf.notation.EMFSemanticIdConverter;
 import org.eclipse.glsp.server.session.ClientSession;
 
 import com.google.inject.Inject;
+import com.google.inject.Singleton;
 
+@Singleton
 public class EMSModelStateImpl extends EMFModelStateImpl implements EMSModelState {
 
    private static final Logger LOGGER = LogManager.getLogger(EMSModelStateImpl.class);

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSGLSPNotationDiagramModule.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSGLSPNotationDiagramModule.java
@@ -12,7 +12,6 @@ package org.eclipse.emfcloud.modelserver.glsp.notation.integration;
 
 import org.eclipse.emfcloud.modelserver.common.ModelServerPathParametersV2;
 import org.eclipse.emfcloud.modelserver.glsp.EMSGLSPDiagramModule;
-import org.eclipse.emfcloud.modelserver.glsp.EMSModelState;
 import org.eclipse.emfcloud.modelserver.glsp.ModelServerAccess;
 import org.eclipse.emfcloud.modelserver.glsp.layout.EMSLayoutEngine;
 import org.eclipse.emfcloud.modelserver.glsp.operations.handlers.EMSChangeBoundsOperationHandler;
@@ -25,6 +24,8 @@ import org.eclipse.glsp.server.emf.model.notation.NotationPackage;
 import org.eclipse.glsp.server.layout.LayoutEngine;
 import org.eclipse.glsp.server.operations.LayoutOperationHandler;
 import org.eclipse.glsp.server.operations.OperationHandler;
+
+import com.google.inject.Singleton;
 
 public abstract class EMSGLSPNotationDiagramModule extends EMSGLSPDiagramModule {
 
@@ -46,8 +47,8 @@ public abstract class EMSGLSPNotationDiagramModule extends EMSGLSPDiagramModule 
    protected String getNotationModelFormat() { return ModelServerPathParametersV2.FORMAT_JSON_V2; }
 
    @Override
-   protected Class<? extends EMSModelState> bindGModelState() {
-      return EMSNotationModelState.class;
+   protected Class<? extends EMSNotationModelState> bindGModelState() {
+      return EMSNotationModelStateImpl.class;
    }
 
    @Override
@@ -79,6 +80,16 @@ public abstract class EMSGLSPNotationDiagramModule extends EMSGLSPDiagramModule 
       binding.rebind(LayoutOperationHandler.class, EMSLayoutOperationHandler.class);
       binding.add(EMSChangeBoundsOperationHandler.class);
       binding.add(EMSChangeRoutingPointsOperationHandler.class);
+   }
+
+   @Override
+   protected void configure() {
+      super.configure();
+      configureEMSNotationModelState(bindGModelState());
+   }
+
+   protected void configureEMSNotationModelState(final Class<? extends EMSNotationModelState> modelState) {
+      bind(EMSNotationModelState.class).to(modelState).in(Singleton.class);
    }
 
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelState.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelState.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2022 EclipseSource and others.
+ * Copyright (c) 2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,36 +14,16 @@ import java.util.Optional;
 
 import org.eclipse.emf.ecore.EObject;
 import org.eclipse.emfcloud.modelserver.glsp.EMSModelState;
-import org.eclipse.glsp.graph.GModelIndex;
-import org.eclipse.glsp.graph.GModelRoot;
 import org.eclipse.glsp.server.emf.model.notation.Diagram;
 import org.eclipse.glsp.server.emf.notation.EMFNotationModelIndex;
-import org.eclipse.glsp.server.session.ClientSession;
 
-public class EMSNotationModelState extends EMSModelState {
-
-   protected Diagram notationModel;
-
+public interface EMSNotationModelState extends EMSModelState {
    @Override
-   protected GModelIndex getOrUpdateIndex(final GModelRoot newRoot) {
-      return EMFNotationModelIndex.getOrCreate(getRoot(), semanticIdConverter);
-   }
+   EMFNotationModelIndex getIndex();
 
-   @Override
-   public EMFNotationModelIndex getIndex() { return (EMFNotationModelIndex) super.getIndex(); }
+   void setNotationModel(final Diagram notationModel);
 
-   public void setNotationModel(final Diagram notationModel) { this.notationModel = notationModel; }
+   Diagram getNotationModel();
 
-   public Diagram getNotationModel() { return this.notationModel; }
-
-   public <T extends EObject> Optional<T> getNotationModel(final Class<T> clazz) {
-      return Optional.ofNullable(this.notationModel).filter(clazz::isInstance).map(clazz::cast);
-   }
-
-   @Override
-   public void sessionDisposed(final ClientSession clientSession) {
-      this.notationModel = null;
-      super.sessionDisposed(clientSession);
-   }
-
+   <T extends EObject> Optional<T> getNotationModel(final Class<T> clazz);
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelState.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelState.java
@@ -21,9 +21,9 @@ public interface EMSNotationModelState extends EMSModelState {
    @Override
    EMFNotationModelIndex getIndex();
 
-   void setNotationModel(final Diagram notationModel);
+   void setNotationModel(Diagram notationModel);
 
    Diagram getNotationModel();
 
-   <T extends EObject> Optional<T> getNotationModel(final Class<T> clazz);
+   <T extends EObject> Optional<T> getNotationModel(Class<T> clazz);
 }

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelStateImpl.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelStateImpl.java
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2022 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelStateImpl.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelStateImpl.java
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2021-2022 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * https://www.eclipse.org/legal/epl-2.0, or the MIT License which is
+ * available at https://opensource.org/licenses/MIT.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR MIT
+ ********************************************************************************/
+package org.eclipse.emfcloud.modelserver.glsp.notation.integration;
+
+import java.util.Optional;
+
+import org.eclipse.emf.ecore.EObject;
+import org.eclipse.emfcloud.modelserver.glsp.EMSModelStateImpl;
+import org.eclipse.glsp.graph.GModelIndex;
+import org.eclipse.glsp.graph.GModelRoot;
+import org.eclipse.glsp.server.emf.model.notation.Diagram;
+import org.eclipse.glsp.server.emf.notation.EMFNotationModelIndex;
+import org.eclipse.glsp.server.session.ClientSession;
+
+public class EMSNotationModelStateImpl extends EMSModelStateImpl implements EMSNotationModelState {
+
+   protected Diagram notationModel;
+
+   @Override
+   protected GModelIndex getOrUpdateIndex(final GModelRoot newRoot) {
+      return EMFNotationModelIndex.getOrCreate(getRoot(), semanticIdConverter);
+   }
+
+   @Override
+   public EMFNotationModelIndex getIndex() { return (EMFNotationModelIndex) super.getIndex(); }
+
+   @Override
+   public void setNotationModel(final Diagram notationModel) { this.notationModel = notationModel; }
+
+   @Override
+   public Diagram getNotationModel() { return this.notationModel; }
+
+   @Override
+   public <T extends EObject> Optional<T> getNotationModel(final Class<T> clazz) {
+      return Optional.ofNullable(this.notationModel).filter(clazz::isInstance).map(clazz::cast);
+   }
+
+   @Override
+   public void sessionDisposed(final ClientSession clientSession) {
+      this.notationModel = null;
+      super.sessionDisposed(clientSession);
+   }
+
+}

--- a/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelStateImpl.java
+++ b/plugins/org.eclipse.emfcloud.modelserver.glsp.integration/src/org/eclipse/emfcloud/modelserver/glsp/notation/integration/EMSNotationModelStateImpl.java
@@ -20,6 +20,9 @@ import org.eclipse.glsp.server.emf.model.notation.Diagram;
 import org.eclipse.glsp.server.emf.notation.EMFNotationModelIndex;
 import org.eclipse.glsp.server.session.ClientSession;
 
+import com.google.inject.Singleton;
+
+@Singleton
 public class EMSNotationModelStateImpl extends EMSModelStateImpl implements EMSNotationModelState {
 
    protected Diagram notationModel;

--- a/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.target
+++ b/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.target
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="EMF.cloud Model Server GLSP Integration Targetplatform" sequenceNumber="1676391947">
+<target name="EMF.cloud Model Server GLSP Integration Targetplatform" sequenceNumber="1681733010">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.glsp.feature.feature.group" version="1.1.0.202302071309"/>
-      <unit id="org.eclipse.glsp.layout" version="1.1.0.202302071309"/>
-      <unit id="org.eclipse.glsp.server.emf" version="1.1.0.202302071309"/>
-      <repository location="https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202302071309/"/>
+      <unit id="org.eclipse.glsp.feature.feature.group" version="1.1.0.202304170825"/>
+      <unit id="org.eclipse.glsp.layout" version="1.1.0.202304170825"/>
+      <unit id="org.eclipse.glsp.server.emf" version="1.1.0.202304170825"/>
+      <repository location="https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202304170825/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
       <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202301260959"/>

--- a/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.tpd
+++ b/releng/org.eclipse.emfcloud.modelserver.glsp.releng.target/targetdefinition.tpd
@@ -1,6 +1,6 @@
 target "EMF.cloud Model Server GLSP Integration Targetplatform" with source requirements
 
-location "https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202302071309/" {
+location "https://download.eclipse.org/glsp/server/p2/nightly/1.1/1.1.0.202304170825/" {
 	org.eclipse.glsp.feature.feature.group [1.0.0, 2.0.0)
 	org.eclipse.glsp.layout [1.0.0, 2.0.0)
 	org.eclipse.glsp.server.emf [1.0.0, 2.0.0)


### PR DESCRIPTION
- Use interfaces for EMSModelState and EMSNotationModelState
- Use these interfaces for binding and injection

Depends on https://github.com/eclipse-glsp/glsp-server/pull/199

refs https://github.com/eclipse-glsp/glsp/issues/974